### PR TITLE
Add ensureconda 1.4.3

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,6 @@
 {% set name = "ensureconda" %}
 {% set version = "1.4.3" %}
 
-
 package:
   name: {{ name|lower }}
   version: {{ version }}
@@ -12,39 +11,48 @@ source:
 
 build:
   number: 0
-  noarch: python
+  skip: True  # [py<37]
   entry_points:
     - ensureconda = ensureconda.cli:ensureconda_cli
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . -vv --no-deps
 
 requirements:
   host:
+    - python
     - pip
-    - python >=3.7
-    - setuptools_scm
-    - hatchling >=0.21.1
+    - hatchling
     - hatch-vcs
+    - wheel
   run:
+    - python
     - appdirs
     - click >=5.1
     - filelock
-    - python >=3.7
     - requests >=2
 
 test:
   imports:
     - ensureconda
+  requires:
+    - pip
   commands:
     - pip check
     - ensureconda --help
-  requires:
-    - pip
 
 about:
   home: https://github.com/conda-incubator/ensureconda
   summary: Install and run applications packaged with conda in isolated environments
   license: MIT
+  license_family: MIT
   license_file: LICENSE-MIT
+  description: |
+    Install and run applications packaged with conda in isolated environments.
+    Ensureconda is a cli tool that will:
+    1. Find a preexisting conda/mamba executable
+    2. Install one if nothing was found and installation is allowed.
+    3. Return the path of the executable found/installed on stdout
+  doc_url: https://github.com/conda-incubator/ensureconda
+  dev_url: https://github.com/conda-incubator/ensureconda
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
Changelog: https://github.com/conda-incubator/ensureconda/releases
License: https://github.com/conda-incubator/ensureconda/blob/v1.4.3/LICENSE-MIT
Requirements: https://github.com/conda-incubator/ensureconda/blob/v1.4.3/pyproject.toml

Actions: 
1. Skip py<37
2. Fix python in host and run
3. Remove pinnings from host
4. Add wheel to host
5. Add license_family
6. Add description
7. Add dev and doc urls

Notes:
- conda-lock requires it