### PR TITLE
ensureconda to 1.4.4 with packaging

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: c0846f8eaa5119c46b2ecfe9bc24ed19dba8845f8655d00b51ddd296a10ea4cb
+  sha256: 2ee70b75f6aa67fca5b72bec514e66deb016792959763cbd48720cfe051a24a4
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "ensureconda" %}
-{% set version = "1.4.3" %}
+{% set version = "1.4.4" %}
 
 package:
   name: {{ name|lower }}
@@ -7,14 +7,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: e04ae2e2f872869df7e7da22dcca9bd7c42f839a55155dddb249bcdc9e6aae48
+  sha256: 2ee70b75f6aa67fca5b72bec514e66deb016792959763cbd48720cfe051a24a4
 
 build:
   number: 0
   skip: True  # [py<37]
   entry_points:
     - ensureconda = ensureconda.cli:ensureconda_cli
-  script: {{ PYTHON }} -m pip install . -vv --no-deps
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:
   host:
@@ -29,6 +29,7 @@ requirements:
     - click >=5.1
     - filelock
     - requests >=2
+    - packaging
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 2ee70b75f6aa67fca5b72bec514e66deb016792959763cbd48720cfe051a24a4
+  sha256: c0846f8eaa5119c46b2ecfe9bc24ed19dba8845f8655d00b51ddd296a10ea4cb
 
 build:
   number: 0
@@ -20,9 +20,8 @@ requirements:
   host:
     - python
     - pip
-    - hatchling
+    - hatchling >=0.21.1
     - hatch-vcs
-    - wheel
   run:
     - python
     - appdirs

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,8 +28,8 @@ requirements:
     - appdirs
     - click >=5.1
     - filelock
-    - requests >=2
     - packaging
+    - requests >=2
 
 test:
   imports:


### PR DESCRIPTION
ensureconda 1.4.4

**Destination channel:** defaults

### Links

- [Upstream repository](https://github.com/conda-incubator/ensureconda)
- [Upstream changelog/diff](https://github.com/conda-incubator/ensureconda/releases/tag/v1.4.4)
- Relevant dependency PRs:
  - Dependency for `conda-lock`

### Explanation of changes:
- `no-build-isolation`
-  added `packaging`
